### PR TITLE
Add some sample tags

### DIFF
--- a/db/seeds/tags.rb
+++ b/db/seeds/tags.rb
@@ -1,0 +1,24 @@
+def create_or_update_tag(options)
+  tag_id = options.delete(:tag_id)
+  tag = Tag.where(:tag_id => tag_id).first || Tag.new(:tag_id => tag_id)
+  tag.update_attributes(options)
+end
+
+create_or_update_tag(
+    tag_type: "section",
+    title: "Global",
+    tag_id: "global",
+    description: "Generic content that should be pulled onto the global site")
+
+create_or_update_tag(
+    tag_type: "section",
+    title: "London",
+    tag_id: "london",
+    description: "Generic content that should be pulled onto the London site")
+
+create_or_update_tag(
+    tag_type: "section",
+    title: "Learning",
+    tag_id: "learning",
+    description: "Generic content that should be pulled onto the learning site")
+


### PR DESCRIPTION
@pezholio: lunch wasn't quite ready, so I started playing with tags. If you run rake db:seed on Panopticon, you should get some tags appearing in the list. The tags appear in the content API tag list so http://frontend.dev/browse works, but when you go into each section, there isn't any content listed. Not sure why, at the moment.
