### PR TITLE
Return to alphagov govuk_content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,17 +31,17 @@ gem 'less-rails-bootstrap'
 gem 'colorize', '~> 0.5.8'
 gem 'rummageable', "~> 0.3.0"
 
-gem "mongoid", "~> 2.4.2"
+gem "mongoid", "~> 2.5"
 gem "mongoid_rails_migrations", "1.0.0"
-gem "mongo", "1.6.2"
+gem "mongo", "1.7.1"
 gem "kaminari", "0.14.1"
-gem "bson_ext", "1.6.2"
-gem "bson", "1.6.2"
+gem "bson_ext", "1.7.1"
+gem "bson", "1.7.1"
 gem 'lograge', '~> 0.1.0'
 
 gem 'language_list'
 
-gem "govuk_content_models", github: 'theodi/govuk_content_models', branch: 'feature-lambda-format-validator'
+gem 'govuk_content_models', '6.0.6'
 
 if ENV['CONTENT_MODELS_DEV']
   gem "odi_content_models", path: '../odi_content_models'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,21 +11,6 @@ GIT
       rest-client (~> 1.6.3)
 
 GIT
-  remote: git://github.com/theodi/govuk_content_models.git
-  revision: d2c8536da24a9ef003e1eb40f5bac2074dfa478b
-  branch: feature-lambda-format-validator
-  specs:
-    govuk_content_models (5.10.0)
-      bson_ext
-      differ
-      gds-api-adapters
-      gds-sso (>= 3.0.0, < 4.0.0)
-      govspeak (>= 1.0.1, < 2.0.0)
-      mongoid (~> 2.4.10)
-      plek
-      state_machine
-
-GIT
   remote: git://github.com/theodi/odi_content_models.git
   revision: 5415c81416c5aed81653b6646f2f965f0125a907
   specs:
@@ -89,9 +74,9 @@ GEM
       mail (> 2.2.5)
       mime-types
       xml-simple
-    bson (1.6.2)
-    bson_ext (1.6.2)
-      bson (~> 1.6.2)
+    bson (1.7.1)
+    bson_ext (1.7.1)
+      bson (~> 1.7.1)
     builder (3.0.4)
     capybara (1.1.2)
       mime-types (>= 1.16)
@@ -157,10 +142,19 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (1.2.5)
+    govspeak (1.3.0)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
+    govuk_content_models (6.0.6)
+      bson_ext
+      differ
+      gds-api-adapters
+      gds-sso (>= 3.0.0, < 4.0.0)
+      govspeak (>= 1.0.1, < 2.0.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
     hashie (2.0.3)
     hike (1.2.2)
     htmlentities (4.3.1)
@@ -218,11 +212,11 @@ GEM
     minitest (3.3.0)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    mongo (1.6.2)
-      bson (~> 1.6.2)
-    mongoid (2.4.12)
+    mongo (1.7.1)
+      bson (~> 1.7.1)
+    mongoid (2.6.0)
       activemodel (~> 3.1)
-      mongo (<= 1.6.2)
+      mongo (~> 1.7)
       tzinfo (~> 0.3.22)
     mongoid_rails_migrations (1.0.0)
       activesupport (>= 3.2.0)
@@ -358,8 +352,8 @@ PLATFORMS
 DEPENDENCIES
   ansi
   aws-ses
-  bson (= 1.6.2)
-  bson_ext (= 1.6.2)
+  bson (= 1.7.1)
+  bson_ext (= 1.7.1)
   capybara (= 1.1.2)
   capybara-mechanize (~> 0.3.0.rc3)
   ci_reporter
@@ -376,7 +370,7 @@ DEPENDENCIES
   gds-api-adapters!
   gds-sso (~> 3.0.5)
   gelf
-  govuk_content_models!
+  govuk_content_models (= 6.0.6)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)
@@ -386,8 +380,8 @@ DEPENDENCIES
   lograge (~> 0.1.0)
   minitest
   mocha (= 0.13.3)
-  mongo (= 1.6.2)
-  mongoid (~> 2.4.2)
+  mongo (= 1.7.1)
+  mongoid (~> 2.5)
   mongoid_rails_migrations (= 1.0.0)
   nested_form (= 0.3.2)
   nokogiri


### PR DESCRIPTION
First part of upgrade all the things, let's get back to using the main alphagov content_models.

Need to do this incrementally else we'll be changing too many things at one time, so this PR get's us to govuk_content_models 6.0.6. I had to upgrade some mongo things as well so I would advise we merge this in the morning @pikesley so we can reboot anything that needs it.
