### PR TITLE
Making amendments to help run in Docker

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -4,3 +4,7 @@ require 'rubygems'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+# Fix to resolver issue - only active if FIX_RESOLV environment variable defined
+if defined? ENV['FIX_RESOLV'] then require 'resolv-replace' end
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,4 +28,6 @@ Panopticon::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
+  if defined? ENV['DOCKERIZED'] then config.logger = Logger.new(STDOUT) end
+
 end

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,12 +1,12 @@
 # This file is overwritten by one in alphagov-deployment at deploy time
 development:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   database: govuk_content_development
   persist_in_safe_mode: true
   use_activesupport_time_zone: true
 
 test:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   # Don't want this interfering with a concurrent Publisher test run
   database: govuk_content_panopticon_test
   use_activesupport_time_zone: true


### PR DESCRIPTION
Environment variables:

`FIX_RESOLV` - if set, require `resolv-replace` (See [ruby-doc](http://ruby-doc.org/stdlib-1.9.3/libdoc/resolv/rdoc/Resolv.html))
`DOCKERIZED` - customisations limited to Docker - mainly logger config.
`MONGOID_HOST` - hostname of mongodb instance. Runs in a separate docker container.